### PR TITLE
Check version agnostic to nginx/openresty installed

### DIFF
--- a/lib/facter/nginx_version.rb
+++ b/lib/facter/nginx_version.rb
@@ -1,8 +1,7 @@
 Facter.add(:nginx_version) do
   setcode do
     if Facter.value('kernel') != 'windows' && (Facter::Util::Resolution.which('nginx') || Facter::Util::Resolution.which('openresty'))
-      nginx_version_command = Facter::Util::Resolution.which('nginx') ? 'nginx -v 2>&1' : 'openresty -v 2>&1'
-      nginx_version = Facter::Util::Resolution.exec(nginx_version_command)
+      nginx_version = Facter::Util::Resolution.exec('nginx -v 2>&1 || openresty -v 2>&1')
       %r{nginx version: (nginx|openresty)\/([\w\.]+)}.match(nginx_version)[2]
     end
   end

--- a/spec/unit/facter/util/fact_nginx_version_spec.rb
+++ b/spec/unit/facter/util/fact_nginx_version_spec.rb
@@ -25,7 +25,18 @@ describe Facter::Util::Fact do
       end
       it { expect(Facter.fact(:nginx_version).value).to eq('0.7.0') }
     end
+
+    context 'symlinked to openresty' do
+      before do
+        allow(Facter::Util::Resolution).to receive(:which).with('openresty') { false }
+        allow(Facter::Util::Resolution).to receive(:which).with('nginx') { true }
+        allow(Facter::Util::Resolution).to receive(:exec).with('openresty -v 2>&1') { 'command not found: openresty' }
+        allow(Facter::Util::Resolution).to receive(:exec).with('nginx -v 2>&1') { 'nginx version: openresty/1.11.2.3' }
+      end
+      it { expect(Facter.fact(:nginx_version).value).to eq('1.11.2.3') }
+    end
   end
+
   context 'openresty' do
     context 'with current version output format' do
       before do


### PR DESCRIPTION
We have systems for which `nginx -v` returns the openresty style version information